### PR TITLE
Remove bad code for fallback upstream_jsonrpc

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -112,11 +112,11 @@ rpc:
   gcn_cache_ttl: 1s # TTL for cached `getClusterNodes`
   request_channel_capacity: 4_096 # Queue size of requests to read threads (be aware, one JSON-RPC request can contain multiple requests)
   # fallback for httpget
-  # upstream_httpget:
-  #   endpoint: http://127.0.0.1:8899
-  #   user_agent: alpamayo/v0.1.0
-  #   version: HTTP/1.1
-  #   timeout: 30s
+  upstream_httpget:
+    endpoint: http://127.0.0.1:8899
+    user_agent: alpamayo/v0.1.0
+    version: HTTP/1.1
+    timeout: 30s
   # Multiple upstream JSON-RPC configuration
   # This allows routing different RPC methods to different upstream endpoints
   upstream_jsonrpc_multiple:

--- a/src/rpc/api_jsonrpc.rs
+++ b/src/rpc/api_jsonrpc.rs
@@ -845,7 +845,6 @@ impl RpcRequestHandler for RpcRequestBlocks {
 
         }
 
-
         // request
         let (tx, rx) = oneshot::channel();
         anyhow::ensure!(
@@ -1467,7 +1466,6 @@ impl RpcRequestInflationReward {
             }
 
         }
-
 
         // request
         let (tx, rx) = oneshot::channel();

--- a/src/rpc/api_jsonrpc.rs
+++ b/src/rpc/api_jsonrpc.rs
@@ -843,20 +843,6 @@ impl RpcRequestHandler for RpcRequestBlocks {
                     .await;
             }
 
-            if let Some(upstream) = self.state.upstream.as_ref() {
-                return upstream
-                    .get_blocks(
-                        Arc::clone(&self.x_subscription_id),
-                        deadline,
-                        &self.id,
-                        self.start_slot,
-                        self.until,
-                        self.commitment,
-                    )
-                    .await;
-            }
-
-            // No upstream configured, continue with local storage
         }
 
 
@@ -1480,15 +1466,6 @@ impl RpcRequestInflationReward {
                     .map_err(|error| anyhow::anyhow!(error));
             }
 
-            // Fallback to legacy single-upstream
-            if let Some(upstream) = self.state.upstream.as_ref() {
-                return upstream
-                    .get_blocks_parsed(deadline, &self.id, start_slot, limit)
-                    .await
-                    .map_err(|error| anyhow::anyhow!(error));
-            }
-
-            // No upstream configured, continue with local storage
         }
 
 

--- a/src/rpc/api_jsonrpc.rs
+++ b/src/rpc/api_jsonrpc.rs
@@ -1458,7 +1458,7 @@ impl RpcRequestInflationReward {
         // some slot will be removed while we pass request, send to upstream
         let first_available_slot = self.state.stored_slots.first_available_load() + 150;
         if start_slot < first_available_slot && !self.upstream_disabled {
-            // Prefer the new upstream manager if configured
+            // Try the new upstream manager first
             if let Some(upstream_manager) = self.state.upstream_manager.as_ref() {
                 return upstream_manager
                     .get_blocks_parsed(deadline, &self.id, start_slot, limit)


### PR DESCRIPTION
These changes were added accidentally when fixing conflicts `https://github.com/lamports-dev/alpamayo/pull/70/commits/439020182850b84c82ca337774b7c2f8543b4a92`

Causing the build to fail

```
   = note: `#[warn(unused_imports)]` on by default
error[E0609]: no field `upstream` on type `Arc<api_jsonrpc::State>`
   --> src/rpc/api_jsonrpc.rs:846:48
    |
846 |             if let Some(upstream) = self.state.upstream.as_ref() {
    |                                                ^^^^^^^^ unknown field
    |
    = note: available fields are: `epoch_schedule`, `stored_slots`, `request_timeout`, `gsfa_limit`, `gss_transaction_history` ... and 5 others
error[E0609]: no field `upstream` on type `Arc<api_jsonrpc::State>`
    --> src/rpc/api_jsonrpc.rs:1484:48
     |
1484 |             if let Some(upstream) = self.state.upstream.as_ref() {
     |                                                ^^^^^^^^ unknown field
     |
     = note: available fields are: `epoch_schedule`, `stored_slots`, `request_timeout`, `gsfa_limit`, `gss_transaction_history` ... and 5 others
error[E0282]: type annotations needed
    --> src/rpc/api_jsonrpc.rs:1488:31
```